### PR TITLE
Prevent against directory traversal attacks.

### DIFF
--- a/nano-server
+++ b/nano-server
@@ -21,12 +21,19 @@
 
 var http = require("http");
 var fs = require("fs");
+var pathlib = require("path");
 var version = "0.3.2";
 var mime_types = getMimeTypes();
 var port = process.argv[2] || 5000;
 var root = process.argv[3] || ".";
+var root_path = pathlib.resolve(root);
 
 http.createServer(function (req, res) {
+  var full_requested_path = pathlib.resolve(root, req.url.replace(/^\/+/, ""));
+  if (full_requested_path.indexOf(root_path) !== 0) {
+    res.writeHead(403);
+    return res.end("Unauthorized.")
+  }
 
   var path = root + "/" + req.url.replace(/^\/+/, "");
   var extension = path.match(/\.[^\.]+$/);


### PR DESCRIPTION
I know this package shouldn't be used in production, however it bothers me that simply asking for `http://localhost:5000/..` lists the parent directory without returning a 403. And checking for this kind of stuff can also be useful in development, just to make sure that all will work well when deploying on a server that checks for directory traversal attacks.

Result:

```
$  curl http://localhost:5000/..
Unauthorized.%
```

---

Check if the full URL we will serve (be it a directory or a file) is contained in the root. Otherwise we return 403, as it means the user is trying to access some directory that should not be accessible.

http://en.wikipedia.org/wiki/Directory_traversal_attack
